### PR TITLE
[fixed]`rails g`コマンドの際にいらないファイルが生成されないように

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,8 @@ module Achieve
     config.i18n.default_locale = :ja
 
     config.generators do |g|
+      g.assets false,
+      g.helper false,
       g.test_framework :rspec,
         fixtures: true,
         view_specs: false,


### PR DESCRIPTION
#1
rails g コマンドによってhelper,assetsが作成されないように