### PR TITLE
[Fixed]デバッグツールのgemをdevelopmentのみに反映

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,13 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+
+  gem 'pry-rails'
+
+  gem 'better_errors'
+
+  gem 'binding_of_caller'
+
 end
 
 group :test do
@@ -91,9 +98,6 @@ gem 'rails_admin'
 
 gem 'cancan'
 
-gem 'pry-rails'
-
-gem 'better_errors'
 
 gem 'activeresource'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -116,6 +118,7 @@ GEM
     concurrent-ruby (1.1.3)
     crass (1.0.4)
     database_cleaner (1.7.0)
+    debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
     devise (4.5.0)
@@ -624,6 +627,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
   cancan


### PR DESCRIPTION
#2 
pry-rails, better_errors, binding_of_callerをdevelopment環境にのみ反映されるように 